### PR TITLE
refactor!: cache extra folders in by actions/cache No.2

### DIFF
--- a/.github/workflows/test_preview_gsd.yaml
+++ b/.github/workflows/test_preview_gsd.yaml
@@ -18,10 +18,9 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           deploy-dir: ./public
-          cache-path: |
+          extra-cache-path: |
             .cache
             public
-            node_modules
           working-directory: ./examples/gatsby-starter-default
       - name: echo outputs
         run: | 

--- a/.github/workflows/test_production_gsd.yaml
+++ b/.github/workflows/test_production_gsd.yaml
@@ -18,9 +18,8 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           deploy-dir: ./public
-          cache-path: |
+          extra-cache-path: |
             .cache
             public
-            node_modules
           working-directory: ./examples/gatsby-starter-default
           production: true

--- a/README.md
+++ b/README.md
@@ -54,19 +54,22 @@ Github action to deploy to Netlify with Comments of Preview and Log URL.
 | node |  | 14 | Node version to run deployment |
 | build-command | △ | yarn build | |
 | install-command | △ | yarn --check-files --frozen-lockfile --non-interactive | ※ You should override it if you're not using yarn as your dependency manager |
-| cache-path | | node_modules | |
 | cache-strategy | △ | yarn | `yarn`, `npm`, or `pnpm` |
+| extra-cache-path | | | extra cache paths(eg: `.cache` in GatsbyJS) |
 | working-directory | | | Working directory of your project |
 
 ## What's `NEW` in this Github action?
 
 1. Automatically cache dependencies of your project.
 
-    You can override `cache-path` and `cache-strategy` to customize the cache.
-2. Add comment with Preview URL and Log URL to your pull request automatically.
+    You can override `cache-strategy` to customize the cache.
+2. Cache extra paths for specific projects.
+
+    You can override `extra-cache-path` to enable extra cache policy(eg: `.cache` & `public` folders for `GatsbyJS`).
+3. Add comment with Preview URL and Log URL to your pull request automatically.
 
     ![comment in pull request](./assets/comment_in_pr.png)
-3. `working-directory` is supported.
+4. `working-directory` is supported.
 
     To deploy your project in sub directory easily, just set `working-directory` like `./packages/my-package`.
 
@@ -95,10 +98,9 @@ Github action to deploy to Netlify with Comments of Preview and Log URL.
               NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN}}
               NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID}}
               deploy-dir: "./public"
-              cache-path: |
+              extra-cache-path: |
                 .cache
                 public
-                node_modules
     ```
 
 2. For production build, create a `.github/workflows/production.yml` file with the following content.
@@ -123,10 +125,9 @@ Github action to deploy to Netlify with Comments of Preview and Log URL.
               NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN}}
               NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID}}
               deploy-dir: "./public"
-              cache-path: |
+              extra-cache-path: |
                 .cache
                 public
-                node_modules
               production: true
     ```
 ### GatsbyJS with npm
@@ -152,10 +153,9 @@ Github action to deploy to Netlify with Comments of Preview and Log URL.
               NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN}}
               NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID}}
               deploy-dir: "./public"
-              cache-path: |
+              extra-cache-path: |
                 .cache
                 public
-                node_modules
               cache-strategy: npm
               install-command: npm install --production
               build-command: npm run build
@@ -183,10 +183,9 @@ Github action to deploy to Netlify with Comments of Preview and Log URL.
               NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN}}
               NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID}}
               deploy-dir: "./public"
-              cache-path: |
+              extra-cache-path: |
                 .cache
                 public
-                node_modules
               production: true
               cache-strategy: npm
               install-command: npm install --production

--- a/action.yml
+++ b/action.yml
@@ -103,17 +103,17 @@ runs:
         path: node_modules
         key: node-v${{ inputs.node }}-${{ steps.info_for_cache.outputs.CACHE_HASH }}
 
+    - name: cache extra paths
+      if: inputs.extra-cache-path != ''
+      uses: actions/cache@v3
+      with:
+        path: ${{ inputs.extra-cache-path }}
+        key: node-v${{ inputs.node }}-${{ github.sha }}
+
     - name: install dependencies
       run: ${{ inputs.install-command }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
-
-    - name: download extra cache
-      if: inputs.extra-cache-path != ''
-      uses: actions/download-artifact@v3
-      with:
-        name: extra-cache
-        path: ${{ inputs.extra-cache-path }}
 
     - name: build
       run: ${{ inputs.build-command }}
@@ -171,10 +171,3 @@ runs:
           - Log URL: ${{ steps.deploy_preview.outputs.NETLIFY_LOGS_URL }}
           - Preview URL: ${{ steps.deploy_preview.outputs.NETLIFY_PREVIEW_URL }}
         edit-mode: replace
-
-    - name: upload extra cache
-      if: inputs.extra-cache-path != ''
-      uses: actions/upload-artifact@v3
-      with:
-        name: extra-cache
-        path: ${{ inputs.extra-cache-path }}

--- a/action.yml
+++ b/action.yml
@@ -30,14 +30,13 @@ inputs:
     description: 'Install command'
     required: false
     default: yarn --check-files --frozen-lockfile --non-interactive
-  cache-path:
-    description: 'Paths for cache'
-    required: false
-    default: node_modules
   cache-strategy:
     description: 'yarn, npm, or pnpm'
     required: false
     default: yarn
+  extra-cache-path:
+    description: 'Extra paths for cache'
+    required: false
   working-directory:
     description: 'Working Directory'
     required: false
@@ -101,13 +100,20 @@ runs:
       if: inputs.cache-strategy != 'pnpm'
       uses: actions/cache@v3
       with:
-        path: ${{ inputs.cache-path }}
+        path: node_modules
         key: node-v${{ inputs.node }}-${{ steps.info_for_cache.outputs.CACHE_HASH }}
 
     - name: install dependencies
       run: ${{ inputs.install-command }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+
+    - name: download extra cache
+      if: inputs.extra-cache-path != ''
+      uses: actions/download-artifact@v3
+      with:
+        name: extra-cache
+        path: ${{ inputs.extra-cache-path }}
 
     - name: build
       run: ${{ inputs.build-command }}
@@ -165,4 +171,10 @@ runs:
           - Log URL: ${{ steps.deploy_preview.outputs.NETLIFY_LOGS_URL }}
           - Preview URL: ${{ steps.deploy_preview.outputs.NETLIFY_PREVIEW_URL }}
         edit-mode: replace
-    
+
+    - name: upload extra cache
+      if: inputs.extra-cache-path != ''
+      uses: actions/upload-artifact@v3
+      with:
+        name: extra-cache
+        path: ${{ inputs.extra-cache-path }}

--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ${{ inputs.extra-cache-path }}
-        key: node-v${{ inputs.node }}-${{ github.sha }}
+        key: extra-cache-v${{ inputs.node }}-${{ github.sha }}
 
     - name: install dependencies
       run: ${{ inputs.install-command }}


### PR DESCRIPTION
**Problem:**
Current cache strategy is using `actions/cache` to cache both `node_modules` & extra folders like `.cache` or `public`.
Contents in extra cache folders(`.cache` & `public`) will change after every build but could only be updated when `yarn.lock` changed.

**Solution:**
Cache `node_modules` in `actions/cache` No.1, but extra cache folders in `actions/cache` No.2 by `github.sha` which will change in every commit to cache the extra folders correctly.

close #19 
